### PR TITLE
deprecate TextGrid filename

### DIFF
--- a/src/main/java/org/m2ci/msp/jtgt/TextGrid.java
+++ b/src/main/java/org/m2ci/msp/jtgt/TextGrid.java
@@ -22,6 +22,7 @@ public class TextGrid {
     private double _end;
 
     /** The filename associated with the textgrid */
+    @Deprecated
     private String _filename;
 
     /*********************************************************************************************
@@ -55,9 +56,23 @@ public class TextGrid {
      * @param filename the filename
      * @param start the start time of the textgrid
      * @param end the end time of the textgrid
+     * @deprecated use {@link #TextGrid(double, double)}
      */
+    @Deprecated
     public TextGrid(String filename, double start, double end) {
         setFilename(filename);
+        setStart(start);
+        setEnd(end);
+        setTiers(new ArrayList<Tier>());
+    }
+
+    /**
+     * Constructor with full information without the tiers
+     *
+     * @param start the start time of the textgrid
+     * @param end the end time of the textgrid
+     */
+    public TextGrid(double start, double end) {
         setStart(start);
         setEnd(end);
         setTiers(new ArrayList<Tier>());
@@ -70,9 +85,24 @@ public class TextGrid {
      * @param start the start time of the textgrid
      * @param end the end time of the textgrid
      * @param tiers the tiers which are going to compose the textgrid
+     * @deprecated use {@link #TextGrid(double, double, ArrayList)}
      */
+    @Deprecated
     public TextGrid(String filename, double start, double end, ArrayList<Tier> tiers) {
         setFilename(filename);
+        setStart(start);
+        setEnd(end);
+        setTiers(tiers);
+    }
+
+    /**
+     * Constructor with full information with the tiers
+     *
+     * @param start the start time of the textgrid
+     * @param end the end time of the textgrid
+     * @param tiers the tiers which are going to comprise the textgrid
+     */
+    public TextGrid(double start, double end, ArrayList<Tier> tiers) {
         setStart(start);
         setEnd(end);
         setTiers(tiers);
@@ -94,7 +124,9 @@ public class TextGrid {
      * Getting the filename
      *
      * @return the filename
+     * @deprecated TextGrids should not have a filename
      */
+    @Deprecated
     public String getFilename() {
         return _filename;
     }
@@ -130,7 +162,9 @@ public class TextGrid {
      * Define the filename
      *
      * @param filename the filename associated to the textgrid
+     * @deprecated TextGrids should not have a filename
      */
+    @Deprecated
     public void setFilename(String filename) {
         this._filename = filename;
     }

--- a/src/main/java/org/m2ci/msp/jtgt/io/TextGridSerializer.java
+++ b/src/main/java/org/m2ci/msp/jtgt/io/TextGridSerializer.java
@@ -117,7 +117,7 @@ public class TextGridSerializer {
                                               ") and the expected number of tiers (" + nb_tiers + ")");
             }
 
-            tgt = new TextGrid(null, xmin, xmax, tiers);
+            tgt = new TextGrid(xmin, xmax, tiers);
 
         } else {
             throw new TextGridIOException("Short format not supported yet or invalid line: \"" + lines.get(0) + "\"");


### PR DESCRIPTION
## Purpose

TextGrids have no concept of "filename", and it makes no sense to have this class field. It only makes sense locally in (de)serialization method arguments.
Note that unlike TextGrids, Tiers *do* have names.

## Approach

The `_filename` class field, its getter/setter methods, and related constructors are deprecated.
